### PR TITLE
flutter engine crash fix

### DIFF
--- a/ios/Classes/SwiftThermalPlugin.swift
+++ b/ios/Classes/SwiftThermalPlugin.swift
@@ -4,6 +4,7 @@ import UIKit
 @available(iOS 11.0, *)
 public class SwiftThermalPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
   var sink: FlutterEventSink?
+  @objc public static var canSendMsg = false
   
   public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
     self.sink = events
@@ -17,6 +18,7 @@ public class SwiftThermalPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
   
   public func onCancel(withArguments arguments: Any?) -> FlutterError? {
     self.sink = nil
+    NotificationCenter.default.removeObserver(self, name: ProcessInfo.thermalStateDidChangeNotification, object: nil)
     return nil
   }
   
@@ -46,8 +48,12 @@ public class SwiftThermalPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
   }
   
   @objc public func onThermalStateChanged() {
-    if let events = self.sink {
-      events(SwiftThermalPlugin.toChannelValue(state: ProcessInfo.processInfo.thermalState))
+    if let events = self.sink, SwiftThermalPlugin.canSendMsg {
+        do {
+            try events(SwiftThermalPlugin.toChannelValue(state: ProcessInfo.processInfo.thermalState))
+        } catch {
+            
+        }
     }
   }
   

--- a/ios/Classes/ThermalPlugin.m
+++ b/ios/Classes/ThermalPlugin.m
@@ -9,7 +9,14 @@
 #endif
 
 @implementation ThermalPlugin
+
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   [SwiftThermalPlugin registerWithRegistrar:registrar];
+  SwiftThermalPlugin.canSendMsg = YES;
 }
+
+- (void)detachFromEngineForRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
+  SwiftThermalPlugin.canSendMsg = NO;
+}
+
 @end


### PR DESCRIPTION
try to fix crash：

```shell
Fatal Exception: NSInternalInconsistencyException
0  CoreFoundation                 0x92c60 (Missing UUID 717d70c93b8e3abcae16050588fc3ee8)
1  libobjc.A.dylib                0x14ee4 objc_exception_throw
2  Foundation                     0x124c80 (Missing UUID c3a840e10d1132a3937f7f668ffb13f0)
3  Flutter                        0x14cf4 -[FlutterEngine sendOnChannel:message:binaryReply:] + 1121 (FlutterEngine.mm:1121)
4  Runner                         0x3c4d1c thunk for @escaping @callee_unowned @convention(block) (@unowned Swift.AnyObject?) -> () (<compiler-generated>)
5  Runner                         0x4a4658 SwiftThermalPlugin.onThermalStateChanged() + 50 (SwiftThermalPlugin.swift:50)
6  Runner                         0x4a469c @objc SwiftThermalPlugin.onThermalStateChanged() (<compiler-generated>)
7  CoreFoundation                 0x2920c (Missing UUID 717d70c93b8e3abcae16050588fc3ee8)
8  CoreFoundation                 0xbe830 (Missing UUID 717d70c93b8e3abcae16050588fc3ee8)
9  CoreFoundation                 0x93b48 (Missing UUID 717d70c93b8e3abcae16050588fc3ee8)
10 CoreFoundation                 0x3dfa0 (Missing UUID 717d70c93b8e3abcae16050588fc3ee8)
11 Foundation                     0x1a00c (Missing UUID c3a840e10d1132a3937f7f668ffb13f0)
12 Foundation                     0xe07d0 (Missing UUID c3a840e10d1132a3937f7f668ffb13f0)
13 libsystem_notify.dylib         0x37c4 notify_cancel

```